### PR TITLE
Add Flutter client conversion

### DIFF
--- a/flutter_client/README.md
+++ b/flutter_client/README.md
@@ -1,0 +1,6 @@
+# Gamr Flutter Client
+
+This directory contains a lightweight Flutter implementation of the original React client.
+The app includes placeholder pages and widgets matching the main features of the web version.
+
+To run the Flutter app, ensure you have Flutter installed and execute `flutter run` from this directory.

--- a/flutter_client/lib/main.dart
+++ b/flutter_client/lib/main.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import 'pages/home_page.dart';
+import 'pages/search_page.dart';
+import 'pages/library_page.dart';
+import 'pages/discover_page.dart';
+import 'pages/profile_page.dart';
+
+void main() {
+  runApp(const GamrApp());
+}
+
+class GamrApp extends StatelessWidget {
+  const GamrApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Gamr',
+      theme: ThemeData.dark(useMaterial3: true),
+      home: const MainNavigation(),
+    );
+  }
+}
+
+class MainNavigation extends StatefulWidget {
+  const MainNavigation({super.key});
+
+  @override
+  State<MainNavigation> createState() => _MainNavigationState();
+}
+
+class _MainNavigationState extends State<MainNavigation> {
+  int _currentIndex = 0;
+
+  final List<Widget> _pages = const [
+    HomePage(),
+    SearchPage(),
+    LibraryPage(),
+    DiscoverPage(),
+    ProfilePage(),
+  ];
+
+  void _onTap(int index) {
+    setState(() {
+      _currentIndex = index;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: _pages[_currentIndex],
+      bottomNavigationBar: BottomNavigationBar(
+        currentIndex: _currentIndex,
+        onTap: _onTap,
+        type: BottomNavigationBarType.fixed,
+        items: const [
+          BottomNavigationBarItem(icon: Icon(Icons.home), label: 'Home'),
+          BottomNavigationBarItem(icon: Icon(Icons.search), label: 'Search'),
+          BottomNavigationBarItem(icon: Icon(Icons.bookmark), label: 'Library'),
+          BottomNavigationBarItem(icon: Icon(Icons.explore), label: 'Discover'),
+          BottomNavigationBarItem(icon: Icon(Icons.person), label: 'Profile'),
+        ],
+      ),
+    );
+  }
+}

--- a/flutter_client/lib/pages/discover_page.dart
+++ b/flutter_client/lib/pages/discover_page.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+class DiscoverPage extends StatelessWidget {
+  const DiscoverPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Discover')),
+      body: const Center(
+        child: Text('Discover new games'),
+      ),
+    );
+  }
+}

--- a/flutter_client/lib/pages/game_detail_page.dart
+++ b/flutter_client/lib/pages/game_detail_page.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+
+class GameDetailPage extends StatelessWidget {
+  final String title;
+  const GameDetailPage({super.key, required this.title});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(title)),
+      body: const Center(
+        child: Text('Game details go here'),
+      ),
+    );
+  }
+}

--- a/flutter_client/lib/pages/home_page.dart
+++ b/flutter_client/lib/pages/home_page.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import '../widgets/game_card.dart';
+
+class HomePage extends StatelessWidget {
+  const HomePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Gamr')),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {},
+        child: const Icon(Icons.add),
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: const [
+          GameCard(
+            title: 'The Legend of Zelda',
+            platform: 'Switch',
+            genre: 'Adventure',
+          ),
+          SizedBox(height: 12),
+          GameCard(
+            title: 'Halo',
+            platform: 'Xbox',
+            genre: 'Shooter',
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/flutter_client/lib/pages/landing_page.dart
+++ b/flutter_client/lib/pages/landing_page.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+class LandingPage extends StatelessWidget {
+  const LandingPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Welcome to Gamr')),
+      body: Center(
+        child: ElevatedButton(
+          onPressed: () {},
+          child: const Text('Login'),
+        ),
+      ),
+    );
+  }
+}

--- a/flutter_client/lib/pages/library_page.dart
+++ b/flutter_client/lib/pages/library_page.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+class LibraryPage extends StatelessWidget {
+  const LibraryPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Library')),
+      body: const Center(
+        child: Text('Your game library'),
+      ),
+    );
+  }
+}

--- a/flutter_client/lib/pages/not_found_page.dart
+++ b/flutter_client/lib/pages/not_found_page.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+
+class NotFoundPage extends StatelessWidget {
+  const NotFoundPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(child: Text('Page not found')),
+    );
+  }
+}

--- a/flutter_client/lib/pages/profile_page.dart
+++ b/flutter_client/lib/pages/profile_page.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+class ProfilePage extends StatelessWidget {
+  const ProfilePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Profile')),
+      body: const Center(
+        child: Text('User profile'),
+      ),
+    );
+  }
+}

--- a/flutter_client/lib/pages/search_page.dart
+++ b/flutter_client/lib/pages/search_page.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+class SearchPage extends StatelessWidget {
+  const SearchPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Search')),
+      body: const Center(
+        child: Text('Search page'),
+      ),
+    );
+  }
+}

--- a/flutter_client/lib/pages/user_profile_page.dart
+++ b/flutter_client/lib/pages/user_profile_page.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+class UserProfilePage extends StatelessWidget {
+  const UserProfilePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('User Profile')),
+      body: const Center(
+        child: Text('Another user\'s profile'),
+      ),
+    );
+  }
+}

--- a/flutter_client/lib/widgets/bottom_navigation.dart
+++ b/flutter_client/lib/widgets/bottom_navigation.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+
+class BottomNavigation extends StatelessWidget {
+  final int currentIndex;
+  final ValueChanged<int> onTap;
+
+  const BottomNavigation({
+    super.key,
+    required this.currentIndex,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return BottomNavigationBar(
+      currentIndex: currentIndex,
+      onTap: onTap,
+      type: BottomNavigationBarType.fixed,
+      items: const [
+        BottomNavigationBarItem(icon: Icon(Icons.home), label: 'Home'),
+        BottomNavigationBarItem(icon: Icon(Icons.search), label: 'Search'),
+        BottomNavigationBarItem(icon: Icon(Icons.bookmark), label: 'Library'),
+        BottomNavigationBarItem(icon: Icon(Icons.explore), label: 'Discover'),
+        BottomNavigationBarItem(icon: Icon(Icons.person), label: 'Profile'),
+      ],
+    );
+  }
+}

--- a/flutter_client/lib/widgets/game_card.dart
+++ b/flutter_client/lib/widgets/game_card.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+
+class GameCard extends StatelessWidget {
+  final String title;
+  final String platform;
+  final String genre;
+
+  const GameCard({
+    super.key,
+    required this.title,
+    required this.platform,
+    required this.genre,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(12.0),
+        child: Row(
+          children: [
+            Container(
+              width: 60,
+              height: 80,
+              color: Colors.grey.shade800,
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(title, style: const TextStyle(fontWeight: FontWeight.bold)),
+                  const SizedBox(height: 4),
+                  Text('$platform • $genre', style: TextStyle(color: Colors.grey.shade400)),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/flutter_client/pubspec.yaml
+++ b/flutter_client/pubspec.yaml
@@ -1,0 +1,14 @@
+name: gamr_flutter
+version: 0.1.0
+publish_to: 'none'
+
+environment:
+  sdk: '>=2.17.0 <3.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  cupertino_icons: ^1.0.5
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- add a Flutter-based client in `flutter_client`

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_686d49481c408331a1df3f05ecf17b29